### PR TITLE
snap: rework for new graphics-core22 design

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
-# nvidia and mesa libraries for core22 snaps
+# Nvidia and Mesa libraries for core22 snaps
 
-A content snap providing the nvidia and mesa userspace libraries and
-drivers for core22
+A content snap providing the Nvidia and Mesa userspace libraries and
+drivers for `base: core22` snaps.
 
 This supplies the graphics-core22 content interface:
 
-    .../lib contains the mesa shared libraries (add to LD_LIBRARY_PATH)
-    .../dri contains the mesa drivers (set LIBGL_DRIVERS_PATH/LIBVA_DRIVERS_PATH to this)
-    .../glvnd/egl_vendor.d contains the mesa ICD (set __EGL_VENDOR_LIBRARY_DIRS to this)
-    .../etc/mir-quirks contains any Mir configuration for driver support (none for mesa)
-    .../libdrm contains mesa configuration for driver support (layout to /usr/share/libdrm) 
-    .../drirc.d contains mesa app-specific workarounds (layout to /usr/share/drirc.d) 
+Path|Description|Use
+--|--|--
+bin/graphics-core22-provider-wrapper|Sets up all the environment|Run your application through it
+||
+drirc.d|App-specific workarounds|Layout to /usr/share/drirc.d
+libdrm|Needed by mesa on AMD GPUs|Layout to /usr/share/libdrm
+X11|X11 locales etc|Layout to /usr/share/X11
+||
+mir-quirks|(optional)Mir configuration|Mir specific
 
 ----
 
-For details on how to get NVIDIA drivers see
-[NVIDIA-assemble](https://github.com/xnox/nvidia-assemble) snap.
-
 For details of the graphics-core22 content interface see:
 
-https://discourse.ubuntu.com/t/the-graphics-core20-snap-interface/23000
+[TBD]

--- a/scripts/bin/graphics-core22-provider-wrapper
+++ b/scripts/bin/graphics-core22-provider-wrapper
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euo pipefail
+
+SELF="$( cd -- "$(dirname "$0")/.." ; pwd -P )"
+
+ARCH_TRIPLET="$(arch)-linux-gnu"
+
+# VDPAU_DRIVER_PATH only supports a single path, rely on LD_LIBRARY_PATH instead
+LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}${SELF}/lib/${ARCH_TRIPLET}:${SELF}/lib/${ARCH_TRIPLET}/vdpau
+LIBGL_DRIVERS_PATH=${LIBGL_DRIVERS_PATH:+$LIBGL_DRIVERS_PATH:}${SELF}/lib/${ARCH_TRIPLET}/dri/
+LIBVA_DRIVERS_PATH=${LIBVA_DRIVERS_PATH:+$LIBVA_DRIVERS_PATH:}${SELF}/lib/${ARCH_TRIPLET}/dri/
+__EGL_VENDOR_LIBRARY_DIRS=${__EGL_VENDOR_LIBRARY_DIRS:+$__EGL_VENDOR_LIBRARY_DIRS:}${SELF}/share/glvnd/egl_vendor.d
+__EGL_EXTERNAL_PLATFORM_CONFIG_DIRS=${__EGL_EXTERNAL_PLATFORM_CONFIG_DIRS:+$__EGL_EXTERNAL_PLATFORM_CONFIG_DIRS:}${SELF}/share/egl/egl_external_platform.d
+VK_LAYER_PATH=${VK_LAYER_PATH:+$VK_LAYER_PATH:}${SELF}/share/vulkan/implicit_layer.d/:${SELF}/share/vulkan/explicit_layer.d/
+XDG_DATA_DIRS=${XDG_DATA_DIRS:+$XDG_DATA_DIRS:}${SELF}/share
+OCL_ICD_VENDORS=${OCL_ICD_VENDORS:+$OCL_ICD_VENDORS:}${SELF}/etc/OpenCL/vendors
+
+export LD_LIBRARY_PATH
+export LIBGL_DRIVERS_PATH
+export LIBVA_DRIVERS_PATH
+export __EGL_VENDOR_LIBRARY_DIRS
+export __EGL_EXTERNAL_PLATFORM_CONFIG_DIRS
+export VK_LAYER_PATH
+export XDG_DATA_DIRS
+
+exec "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,6 +19,7 @@ parts:
     #   o libEGL.so.1
     #   o libva.so.2
     #   o libvulkan.so.1
+    #   o libgbm.so.1
     #
     plugin: nil
     stage-packages:
@@ -26,6 +27,7 @@ parts:
       - libegl1
       - libgles2
       - libvulkan1
+      - libgbm1
     prime:
       - usr/lib
       - usr/share/glvnd

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,10 +13,6 @@ architectures:
   - build-on: arm64
 
 parts:
-  scripts:
-    plugin: dump
-    source: scripts
-
   apis:
     # This provides the essential APIs
     #   o libGL.so.0
@@ -135,6 +131,32 @@ parts:
         echo -n "+mesa"
         apt-cache policy libgl1-mesa-dri | sed -rne 's/^\s+Candidate:\s+([^-]*)-.+$/\1/p'
       )"
+
+  file-list:
+    after:
+    - apis
+    - drm
+    - dri
+    - va
+    - x11
+    - wayland
+    - nvidia
+    plugin: nil
+    override-prime: |
+      mkdir -p ${CRAFT_PRIME}/snap
+      (
+        cd ${CRAFT_PART_INSTALL}/../..
+        # All the cruft coming from stage packages, but not actually staged
+        find $( ls -d */install/{etc,usr/{bin,share/{bug,doc,lintian,man}}} ) -type f,l | cut -d/ -f3-
+        cd ${CRAFT_PRIME}
+        # Everything that is indeed staged
+        find usr -type f,l
+      ) | sort -u > ${CRAFT_PRIME}/snap/${CRAFT_TARGET_ARCH}.list
+
+  scripts:
+    after: [file-list]
+    plugin: dump
+    source: scripts
 
 slots:
   graphics-core22:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,15 +13,102 @@ architectures:
   - build-on: arm64
 
 parts:
-  nvidia:
+  scripts:
+    plugin: dump
+    source: scripts
+
+  apis:
+    # This provides the essential APIs
+    #   o libGL.so.0
+    #   o libEGL.so.1
+    #   o libva.so.2
+    #   o libvulkan.so.1
+    #   o libGLX.so.0
+    #
     plugin: nil
-    override-pull:
-      snapcraftctl set-version `LANG=C apt-cache policy libnvidia-common-515-server | sed -rne 's/^\s+Candidate:\s+([^-]*)-.+$/\1/p'`
+    stage-packages:
+      - libgl1
+      - libegl1
+      - libgles2
+      - libvulkan1
+      - libglx0
+    prime:
+      - usr/lib
+      - usr/share/glvnd
+
+  drm:
+    # DRM userspace
+    #   o libdrm.so.2
+    plugin: nil
+    stage-packages:
+      - libdrm2
+      - libdrm-common
+    prime:
+      - usr/lib
+      - usr/share/libdrm
+
+  va:
+    # Video Acceleration API
+    #   o libva.so.2
+    plugin: nil
+    stage-packages:
+      - libva2
+    prime:
+      - usr/lib
+
+  dri:
+    # Userspace drivers
+    plugin: nil
     stage-packages:
       - libgl1-mesa-dri
       - va-driver-all
-      - libegl1
-      - libgles2
+      - vdpau-driver-all
+      - libvdpau-va-gl1
+      - mesa-vulkan-drivers
+      - libglx-mesa0
+    prime:
+      - usr/lib
+      - usr/share/vulkan
+      - usr/share/drirc.d
+    override-stage: |
+      sed -i 's@/usr/lib/[a-z0-9_-]\+/@@' ${CRAFT_PART_INSTALL}/usr/share/vulkan/*/*.json
+      craftctl default
+
+  x11:
+    # X11 support (not much cost to having this)
+    plugin: nil
+    stage-packages:
+      - libva-x11-2
+      - libx11-xcb1
+      - libxau6
+      - libxcb-dri2-0
+      - libxcb-dri3-0
+      - libxcb-present0
+      - libxcb-sync1
+      - libxcb-xfixes0
+      - libxcb1
+      - libxdamage1
+      - libxdmcp6
+      - libxshmfence1
+    prime:
+      - usr/lib
+      - usr/share/X11
+
+  wayland:
+    # Wayland support (not much cost to having this)
+    plugin: nil
+    stage-packages:
+      - libwayland-client0
+      - libwayland-egl1
+      - libwayland-server0
+      - libnvidia-egl-wayland1
+    prime:
+      - usr/lib
+      - usr/share/egl/egl_external_platform.d
+
+  nvidia:
+    plugin: nil
+    stage-packages:
       - libnvidia-egl-wayland1
       - libnvidia-cfg1-515-server
       - libnvidia-common-515-server
@@ -31,22 +118,37 @@ parts:
       - libnvidia-extra-515-server
       - libnvidia-gl-515-server
       - libnvidia-fbc1-515-server
-    organize:
-      'usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/dri/*': egl/dri/
-      'usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/*.so*': egl/lib/
-      'usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/vdpau/*.so*': egl/lib/vdpau/
-      'usr/share/glvnd': egl/glvnd/
-      'usr/share/libdrm': egl/libdrm/
-      'usr/share/drirc.d/': egl/drirc.d/
-      'etc/OpenCL': egl/OpenCL/
-      'usr/share/vulkan': egl/vulkan/
-      'usr/share/doc': doc/
     prime:
-      - egl
-      - doc
+      - etc/OpenCL
+      - usr/lib
+      - usr/share/glvnd
+      - usr/share/egl
+      - usr/share/nvidia
+      - usr/share/vulkan
+
+  version:
+    plugin: nil
+    override-pull: |
+      set -x
+      craftctl set version="$(
+        LANG=C
+        apt-cache policy libnvidia-common-515-server | sed -rne 's/^\s+Candidate:\s+([^-]*)-.+$/\1/p' | tr -d '\n'
+        echo -n "+mesa"
+        apt-cache policy libgl1-mesa-dri | sed -rne 's/^\s+Candidate:\s+([^-]*)-.+$/\1/p'
+      )"
 
 slots:
   graphics-core22:
     interface: content
-    read:
-      - egl
+    source:
+      read:
+        # Required at the top-level by graphics-core22
+        - $SNAP/bin
+        - $SNAP/usr/share/drirc.d
+        - $SNAP/usr/share/libdrm
+        - $SNAP/usr/share/X11
+
+        # Internal, pointed at by the above wrapper
+        - $SNAP/etc
+        - $SNAP/usr/lib
+        - $SNAP/usr/share

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,7 +23,6 @@ parts:
     #   o libEGL.so.1
     #   o libva.so.2
     #   o libvulkan.so.1
-    #   o libGLX.so.0
     #
     plugin: nil
     stage-packages:
@@ -31,7 +30,6 @@ parts:
       - libegl1
       - libgles2
       - libvulkan1
-      - libglx0
     prime:
       - usr/lib
       - usr/share/glvnd
@@ -78,6 +76,7 @@ parts:
     # X11 support (not much cost to having this)
     plugin: nil
     stage-packages:
+      - libglx0
       - libva-x11-2
       - libx11-xcb1
       - libxau6

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,9 +1,9 @@
 name: nvidia-core22
 base: core22
-adopt-info: nvidia
-summary: nvidia and mesa libraries for core22 snaps
+adopt-info: version
+summary: Nnvidia and Mesa libraries for core22 snaps
 description: |
-  An experimental content snap containing the nvidia and mesa libraries and drivers for core 20
+  An experimental content snap containing the Nvidia and Mesa libraries and drivers for `base: core22` snaps
 compression: lzo
 grade: stable
 confinement: strict


### PR DESCRIPTION
This moves the responsibility of setting the environment into the provider, with the consumer only needing to wrap its execution with the provided wrapper, rather than setting the environment up on their own.