### PR TITLE
snap: drop libdrm

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Path|Description|Use
 bin/graphics-core22-provider-wrapper|Sets up all the environment|Run your application through it
 ||
 drirc.d|App-specific workarounds|Layout to /usr/share/drirc.d
-libdrm|Needed by mesa on AMD GPUs|Layout to /usr/share/libdrm
 X11|X11 locales etc|Layout to /usr/share/X11
 ||
 mir-quirks|(optional)Mir configuration|Mir specific

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,17 +32,6 @@ parts:
       - usr/lib
       - usr/share/glvnd
 
-  drm:
-    # DRM userspace
-    #   o libdrm.so.2
-    plugin: nil
-    stage-packages:
-      - libdrm2
-      - libdrm-common
-    prime:
-      - usr/lib
-      - usr/share/libdrm
-
   va:
     # Video Acceleration API
     #   o libva.so.2
@@ -137,7 +126,6 @@ parts:
   file-list:
     after:
     - apis
-    - drm
     - dri
     - va
     - x11
@@ -168,7 +156,6 @@ slots:
         # Required at the top-level by graphics-core22
         - $SNAP/bin
         - $SNAP/usr/share/drirc.d
-        - $SNAP/usr/share/libdrm
         - $SNAP/usr/share/X11
 
         # Internal, pointed at by the above wrapper


### PR DESCRIPTION
It's part of the base after all:

https://forum.snapcraft.io/t/core22-is-libdrm-there-to-stay/34341