### PR TITLE
Revert "snap: drop libdrm"

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,4 @@ mir-quirks|(optional)Mir configuration|Mir specific
 
 ----
 
-For details of the graphics-core22 content interface see:
-
-[TBD]
+For more information about the `graphics-core22` interface, see: [The graphics-core22 snap interface](https://mir-server.io/docs/the-graphics-core22-snap-interface) documentation.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Path|Description|Use
 bin/graphics-core22-provider-wrapper|Sets up all the environment|Run your application through it
 ||
 drirc.d|App-specific workarounds|Layout to /usr/share/drirc.d
+libdrm|Needed by mesa on AMD GPUs|Layout to /usr/share/libdrm
 X11|X11 locales etc|Layout to /usr/share/X11
 ||
 mir-quirks|(optional)Mir configuration|Mir specific

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,6 +33,17 @@ parts:
       - usr/lib
       - usr/share/glvnd
 
+  drm:
+    # DRM userspace
+    #   o libdrm.so.2
+    plugin: nil
+    stage-packages:
+      - libdrm2
+      - libdrm-common
+    prime:
+      - usr/lib
+      - usr/share/libdrm
+
   va:
     # Video Acceleration API
     #   o libva.so.2
@@ -127,6 +138,7 @@ parts:
   file-list:
     after:
     - apis
+    - drm
     - dri
     - va
     - x11
@@ -157,6 +169,7 @@ slots:
         # Required at the top-level by graphics-core22
         - $SNAP/bin
         - $SNAP/usr/share/drirc.d
+        - $SNAP/usr/share/libdrm
         - $SNAP/usr/share/X11
 
         # Internal, pointed at by the above wrapper


### PR DESCRIPTION
This reverts commit 98d4044af02c2817a542f9d18cace28249a0d313.

Still don't have access to the core22 snap version: https://github.com/snapcore/snapd/pull/12694; also realized it's potentially needed for newer AMD GPUs.