### PR TITLE
Add nvidia-smi util

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -117,6 +117,9 @@ parts:
       - libnvidia-extra-525-server
       - libnvidia-gl-525-server
       - libnvidia-fbc1-525-server
+      - nvidia-utils-525-server
+    organize:
+      'usr/bin/*': bin/
     prime:
       - etc/OpenCL
       - usr/lib
@@ -124,6 +127,7 @@ parts:
       - usr/share/egl
       - usr/share/nvidia
       - usr/share/vulkan
+      - bin/nvidia-smi
 
   version:
     plugin: nil
@@ -161,6 +165,12 @@ parts:
     after: [file-list]
     plugin: dump
     source: scripts
+
+apps:
+  smi:
+    command: bin/nvidia-smi
+    plugs:
+      - opengl
 
 slots:
   graphics-core22:


### PR DESCRIPTION
The nvidia-smi utility is generally bundled with userspace components to help check hardware detection and features/functionality.  This seems like a good/reasonable place to add it, exposing via the content interface to make it usable via that mechanism.

Having the utility available as an app also enables quick testing/validation one this snap is installed.

Closes https://github.com/snapcore/nvidia-core22/issues/9