### PR TITLE
snap: update nvidia driver to 535

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -109,15 +109,15 @@ parts:
     plugin: nil
     stage-packages:
       - libnvidia-egl-wayland1
-      - libnvidia-cfg1-525-server
-      - libnvidia-common-525-server
-      - libnvidia-compute-525-server
-      - libnvidia-decode-525-server
-      - libnvidia-encode-525-server
-      - libnvidia-extra-525-server
-      - libnvidia-gl-525-server
-      - libnvidia-fbc1-525-server
-      - nvidia-utils-525-server
+      - libnvidia-cfg1-535-server
+      - libnvidia-common-535-server
+      - libnvidia-compute-535-server
+      - libnvidia-decode-535-server
+      - libnvidia-encode-535-server
+      - libnvidia-extra-535-server
+      - libnvidia-gl-535-server
+      - libnvidia-fbc1-535-server
+      - nvidia-utils-535-server
     organize:
       'usr/bin/*': bin/
     prime:
@@ -135,7 +135,7 @@ parts:
       set -x
       craftctl set version="$(
         LANG=C
-        apt-cache policy libnvidia-common-525-server | sed -rne 's/^\s+Candidate:\s+([^-]*)-.+$/\1/p' | tr -d '\n'
+        apt-cache policy libnvidia-common-535-server | sed -rne 's/^\s+Candidate:\s+([^-]*)-.+$/\1/p' | tr -d '\n'
         echo -n "+mesa"
         apt-cache policy libgl1-mesa-dri | sed -rne 's/^\s+Candidate:\s+([^-]*)-.+$/\1/p'
       )"


### PR DESCRIPTION
The `pc-kernel` snap on beta has the new driver:

```
[  928.749445] NVRM: API mismatch: the client has the version 525.147.05, but
               NVRM: this kernel module has the version 535.161.07.  Please
               NVRM: make sure that this kernel module and all NVIDIA driver
               NVRM: components have the same version.
```