### PR TITLE
snap: use ldconfig to ensure all symlinks are present

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -166,6 +166,12 @@ parts:
     plugin: dump
     source: scripts
 
+  symlinks:
+    after: [file-list]
+    plugin: nil
+    override-prime: |
+      ldconfig -N -r $CRAFT_PRIME
+
 apps:
   smi:
     command: bin/nvidia-smi


### PR DESCRIPTION
Upon installation of the various libraries via deb package, some symlinks are not shipped with the deb packages, but rather created by `ldconfig`, which is called via `postinst` script (in particular I'm running into issues with `libnvidia-ngx.so.1 -> libnvidia-ngx.so.X.Y.Z` from `libnvidia-gl-XXX-server`). Snapcraft does not call `postinst` scripts for stage-packages.

This PR uses ldconfig to automatically create symlinks after all .so* files have been staged. These symlinks will then be available to other snaps which consume this snap via content interface, without caring about the specific X.Y.Z suffix on those libs. 