### PR TITLE
snap: add missing components

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,7 +19,6 @@ parts:
     # This provides the essential APIs
     #   o libGL.so.0
     #   o libEGL.so.1
-    #   o libva.so.2
     #   o libvulkan.so.1
     #   o libgbm.so.1
     #
@@ -48,9 +47,15 @@ parts:
   va:
     # Video Acceleration API
     #   o libva.so.2
+    #   o libva-drm.so.2
+    #   o libva-x11.so.2
+    #   o libva-wayland.so.2
     plugin: nil
     stage-packages:
       - libva2
+      - libva-drm2
+      - libva-x11-2
+      - libva-wayland2
     prime:
       - usr/lib
 
@@ -77,7 +82,6 @@ parts:
     plugin: nil
     stage-packages:
       - libglx0
-      - libva-x11-2
       - libx11-xcb1
       - libxau6
       - libxcb-dri2-0
@@ -98,6 +102,7 @@ parts:
     plugin: nil
     stage-packages:
       - libwayland-client0
+      - libwayland-cursor0
       - libwayland-egl1
       - libwayland-server0
       - libnvidia-egl-wayland1


### PR DESCRIPTION
These were missed originally, and are expected to be there:

https://mir-server.io/docs/the-graphics-core22-snap-interface

Ref. canonical/mesa-core22#16