### PR TITLE
snap: use -server versions across the board

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -123,7 +123,7 @@ parts:
       - libnvidia-gl-535-server
       - libnvidia-fbc1-535-server
       - nvidia-utils-535-server
-      - xserver-xorg-video-nvidia-535
+      - xserver-xorg-video-nvidia-535-server
     organize:
       'usr/bin/*': bin/
     prime:


### PR DESCRIPTION
They may move at different speeds, and now we have 535.216.03 in -server, but 535.183.01 outside…